### PR TITLE
Fix quality parameter for getDataURL()

### DIFF
--- a/src/WebMWriter.js
+++ b/src/WebMWriter.js
@@ -64,7 +64,7 @@
          */
         function renderAsWebP(canvas, quality) {
             var
-                frame = canvas.toDataURL('image/webp', {quality: quality});
+                frame = canvas.toDataURL('image/webp', quality);
             
             return decodeBase64WebPDataURL(frame);
         }
@@ -618,7 +618,7 @@
                 }
     
                 var
-                    webP = renderAsWebP(canvas, {quality: options.quality});
+                    webP = renderAsWebP(canvas, options.quality);
                 
                 if (!webP) {
                     throw "Couldn't decode WebP frame, does the browser support WebP?";


### PR DESCRIPTION
According to the documentation [1] the function `canvas.getDataURL()` takes a quality level as second parameter. It is expected that this parameter is a number in the range [0,1] rather than an object. This wasn't visible as an error, because the documentation also says: "If this argument is anything else, the default value for image quality is used. The default value is 0.92. Other arguments are ignored."

[1] https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL