### PR TITLE
Check if frameDuration is a number

### DIFF
--- a/src/WebMWriter.js
+++ b/src/WebMWriter.js
@@ -775,7 +775,12 @@
                         throw new Error("Missing required frameDuration or frameRate setting");
                     }
                 }
-                
+
+                // frameDuration value has to be a number, otherwise there is unusual behavior without an error message
+                if (options.frameDuration && typeof options.frameDuration !== "number") {
+                        throw new Error("frameDuration value has to be a number. But it's a " + typeof options.frameDuration);
+                }
+
                 // Avoid 1.0 (lossless) because it creates VP8L lossless frames that WebM doesn't support
                 options.quality = Math.max(Math.min(options.quality, 0.99999), 0);
                 


### PR DESCRIPTION
I've taken value for `frameDuration` from a slider. As a result, I got super long videos even though they should only be seconds long. There was no error message, so it took me a while to find out that the value from the slider is a string and that I have to convert it to an integer first.

I thought about converting the value automatically via `parsInt`, but I like it better when the input values are checked and an error message is thrown out.